### PR TITLE
Corrects deprecation dates for mri

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,6 +12,7 @@ api = "0.2"
     ruby = "2.7.*"
 
   [[metadata.dependencies]]
+    deprecation_date = "2021-03-31T00:00:00Z"
     id = "ruby"
     name = "Ruby"
     sha256 = "8ee7463635739d48ba823a2cda6bcef9914d04c0f6bd6c5fb00bcff5ed7c408e"
@@ -22,6 +23,7 @@ api = "0.2"
     version = "2.5.7"
 
   [[metadata.dependencies]]
+    deprecation_date = "2021-03-31T00:00:00Z"
     id = "ruby"
     name = "Ruby"
     sha256 = "4749d33a4385cb5cc61dd6e460d474132277fda76cc542e1cdfe45b0df93bdc8"
@@ -52,7 +54,6 @@ api = "0.2"
     version = "2.6.6"
 
   [[metadata.dependencies]]
-    deprecation_date = "2023-04-01T00:00:00Z"
     id = "ruby"
     name = "Ruby"
     sha256 = "c892f69b474a9669320b11b324f1a3efb4bc7a8a6409f4274aef0056a82a2161"
@@ -63,7 +64,6 @@ api = "0.2"
     version = "2.7.1"
 
   [[metadata.dependencies]]
-    deprecation_date = "2023-04-01T00:00:00Z"
     id = "ruby"
     name = "Ruby"
     sha256 = "f675ceed2dd7c64b8b69a3aff39416aff2dff75a8b9e1c309a01a5760968ad9e"
@@ -82,12 +82,6 @@ api = "0.2"
     stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
     uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.0.0_linux_x64_cflinuxfs3_1f48565b.tgz"
     version = "3.0.0"
-
-  [[metadata.dependency_deprecation_dates]]
-    date = 2023-04-01T00:00:00Z
-    link = "https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/"
-    name = "ruby"
-    version_line = "2.7.x"
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Fixes the deprecation dates for 2.5 and removes the date for 2.7 as it is not yet specified.

Resolves #138

cc/ @paketo-buildpacks/dependencies-maintainers

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
