### PR TITLE
add `runs-on` to bot approval workflow

### DIFF
--- a/.github/workflows/approve-bot-pr.yml
+++ b/.github/workflows/approve-bot-pr.yml
@@ -12,6 +12,7 @@ jobs:
     if: >
       ${{ github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
     outputs:
       pr-author: ${{ steps.check-pr-author.outputs.author }}
     steps:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The bot approval workflow [is failing](https://github.com/paketo-buildpacks/mri/actions/runs/821647125) since the first job was missing `runs-on`. This PR adds that.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
