### PR TITLE
Use GitHub event_path for workflow artifact lookup

### DIFF
--- a/.github/workflows/approve-bot-pr.yml
+++ b/.github/workflows/approve-bot-pr.yml
@@ -22,7 +22,7 @@ jobs:
           name: "event-payload"
           repo: ${{ github.repository }}
           run_id: ${{ github.event.workflow_run.id }}
-          workspace: ${{ github.workspace }}
+          workspace: ${{ github.event_path }}
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
       - id: check-pr-author
         run: |


### PR DESCRIPTION
The [test pull request workflow](https://github.com/paketo-buildpacks/mri/blob/2abbd558734403fd30ae2bad6461d98c14693237/.github/workflows/test-pull-request.yml#L52) uploads the payload to ‘github.event_path’ so we should look here for the artifact rather than the workspace.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
