### PR TITLE
Read event.json before github workspace gets cleared for approval job

### DIFF
--- a/.github/workflows/approve-bot-pr.yml
+++ b/.github/workflows/approve-bot-pr.yml
@@ -31,6 +31,7 @@ jobs:
       - id: get-pr-number
         run: |
           echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+
   approve:
     name: Approve Bot PRs
     needs: download

--- a/.github/workflows/approve-bot-pr.yml
+++ b/.github/workflows/approve-bot-pr.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pr-author: ${{ steps.check-pr-author.outputs.author }}
+      pr-number: ${{ steps.get-pr-number.outputs.number }}
     steps:
       - name: 'Download artifact'
         uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@approve-bot-prs
@@ -27,6 +28,9 @@ jobs:
       - id: check-pr-author
         run: |
           echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login' | sed s/^v//)"
+      - id: get-pr-number
+        run: |
+          echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
   approve:
     name: Approve Bot PRs
     needs: download
@@ -35,18 +39,13 @@ jobs:
       needs.download.outputs.pr-author == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Retrieve pull request number
-      run: |
-        echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
-      id: pull_request_number
-
     - name: Check Commit Verification
       id: unverified-commits
       uses: paketo-buildpacks/github-config/actions/pull-request/check-unverified-commits@main
       with:
         token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
         repo: ${{ github.repository }}
-        number: ${{ steps.pull_request_number.outputs.number }}
+        number: ${{ needs.download.outputs.pr-number }}
 
     - name: Check for Human Commits
       id: human-commits
@@ -54,7 +53,7 @@ jobs:
       with:
         token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
         repo: ${{ github.repository }}
-        number: ${{ steps.pull_request_number.outputs.number }}
+        number: ${{ needs.download.outputs.pr-number }}
 
     - name: Checkout
       if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
@@ -65,4 +64,4 @@ jobs:
       uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
       with:
         token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
-        number: ${{ steps.pull_request_number.outputs.number }}
+        number: ${{ needs.download.outputs.pr-number }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The bot approval workflow appears to be failing now (see [this run](https://github.com/paketo-buildpacks/mri/runs/2560407432?check_suite_focus=true)) due to not being able to find the `event.json` file.  It fails to find the file at the `Retreive pull request number` step.

At first I thought the path might be wrong, but it appears that the `Checkout` job before the `Approve` job clears the contents of `home/runner/work/mri/mri` which has been mounted to `/github/workspace`. The workspace directory contains the `event.json`.

This PR moves the reading of the PR number from the `event.json` to the previous job so that we can access that information before it gets cleared up.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
