### PR TITLE
Removes support for MRI 2.6.*

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -18,32 +18,6 @@ api = "0.6"
     ruby = "2.7.*"
 
   [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:ruby-lang:ruby:2.6.8:*:*:*:*:*:*:*"
-    id = "ruby"
-    licenses = ["BSD-2-Clause", "BSD-2-Clause-NetBSD", "BSD-3-Clause", "BSD-3-Clause-No-Nuclear-License-2014", "Bison-exception-2.2", "GPL-2.0-only", "GPL-2.0-or-later", "MIT", "MIT-0", "Ruby", "deprecated_GPL-2.0", "deprecated_GPL-2.0+"]
-    name = "Ruby"
-    purl = "pkg:generic/ruby@2.6.8?checksum=1807b78577bc08596a390e8a41aede37b8512190e05c133b17d0501791a8ca6d&download_url=https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.8.tar.gz"
-    sha256 = "188b0ad5b9e88250e77b0a876d0a24e1879ffcabdaee90a01fd23dc14d162a25"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.8.tar.gz"
-    source_sha256 = "1807b78577bc08596a390e8a41aede37b8512190e05c133b17d0501791a8ca6d"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://deps.paketo.io/ruby/ruby_2.6.8_linux_x64_bionic_188b0ad5.tgz"
-    version = "2.6.8"
-
-  [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:ruby-lang:ruby:2.6.9:*:*:*:*:*:*:*"
-    id = "ruby"
-    licenses = ["BSD-2-Clause", "BSD-2-Clause-NetBSD", "BSD-3-Clause", "BSD-3-Clause-No-Nuclear-License-2014", "Bison-exception-2.2", "GPL-2.0-only", "GPL-2.0-or-later", "MIT", "MIT-0", "Ruby", "deprecated_GPL-2.0", "deprecated_GPL-2.0+"]
-    name = "Ruby"
-    purl = "pkg:generic/ruby@2.6.9?checksum=eb7bae7aac64bf9eb2153710a4cafae450ccbb62ae6f63d573e1786178b0efbb&download_url=https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.9.tar.gz"
-    sha256 = "2b731279e0601c312c37293df877f4d9deb6c51391ba0ef3920bea9722e617bf"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.9.tar.gz"
-    source_sha256 = "eb7bae7aac64bf9eb2153710a4cafae450ccbb62ae6f63d573e1786178b0efbb"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://deps.paketo.io/ruby/ruby_2.6.9_linux_x64_bionic_2b731279.tgz"
-    version = "2.6.9"
-
-  [[metadata.dependencies]]
     cpe = "cpe:2.3:a:ruby-lang:ruby:2.7.4:*:*:*:*:*:*:*"
     id = "ruby"
     licenses = ["BSD-2-Clause", "BSD-2-Clause-NetBSD", "BSD-3-Clause", "BSD-3-Clause-No-Nuclear-License-2014", "Bison-exception-2.2", "GPL-2.0-only", "GPL-2.0-or-later", "MIT", "MIT-0", "Ruby", "deprecated_GPL-2.0", "deprecated_GPL-2.0+"]
@@ -120,11 +94,6 @@ api = "0.6"
     stacks = ["io.buildpacks.stacks.bionic"]
     uri = "https://deps.paketo.io/ruby/ruby_3.1.1_linux_x64_bionic_2b27e266.tgz"
     version = "3.1.1"
-
-  [[metadata.dependency-constraints]]
-    constraint = "2.6.*"
-    id = "ruby"
-    patches = 2
 
   [[metadata.dependency-constraints]]
     constraint = "2.7.*"

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -242,7 +242,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 
 			// Second pack build
 			secondImage, logs, err = build.
-				WithEnv(map[string]string{"BP_MRI_VERSION": "2.6.x"}).
+				WithEnv(map[string]string{"BP_MRI_VERSION": "3.0.x"}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -256,28 +256,28 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Resolving MRI version",
 				"    Candidate version sources (in priority order):",
-				"      BP_MRI_VERSION -> \"2.6.x\"",
+				"      BP_MRI_VERSION -> \"3.0.x\"",
 				"      <unknown>      -> \"\"",
 			))
 
 			Expect(logs).To(ContainLines(
-				MatchRegexp(`    Selected MRI version \(using BP_MRI_VERSION\): 2\.6\.\d+`),
+				MatchRegexp(`    Selected MRI version \(using BP_MRI_VERSION\): 3\.0\.\d+`),
 			))
 
 			Expect(logs).To(ContainLines(
 				"  Executing build process",
-				MatchRegexp(`    Installing MRI 2\.6\.\d+`),
+				MatchRegexp(`    Installing MRI 3\.0\.\d+`),
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 			))
 
 			Expect(logs).To(ContainLines(
 				"  Configuring build environment",
-				MatchRegexp(fmt.Sprintf(`    GEM_PATH -> "/home/cnb/.gem/ruby/2\.6\.\d+:/layers/%s/mri/lib/ruby/gems/2\.6\.\d+"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))),
+				MatchRegexp(fmt.Sprintf(`    GEM_PATH -> "/home/cnb/.local/share/gem/ruby/3\.0\.\d+:/layers/%s/mri/lib/ruby/gems/3\.0\.\d+"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))),
 			))
 
 			Expect(logs).To(ContainLines(
 				"  Configuring launch environment",
-				MatchRegexp(fmt.Sprintf(`    GEM_PATH -> "/home/cnb/.gem/ruby/2\.6\.\d+:/layers/%s/mri/lib/ruby/gems/2\.6\.\d+"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))),
+				MatchRegexp(fmt.Sprintf(`    GEM_PATH -> "/home/cnb/.local/share/gem/ruby/3\.0\.\d+:/layers/%s/mri/lib/ruby/gems/3\.0\.\d+"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))),
 			))
 
 			secondContainer, err = docker.Container.Run.
@@ -291,7 +291,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			containerIDs[secondContainer.ID] = struct{}{}
 
 			Eventually(secondContainer).Should(BeAvailable())
-			Eventually(secondContainer).Should(Serve(MatchRegexp(`Hello from Ruby 2\.6\.\d+`)).OnPort(8080))
+			Eventually(secondContainer).Should(Serve(MatchRegexp(`Hello from Ruby 3\.0\.\d+`)).OnPort(8080))
 
 			Expect(secondImage.Buildpacks[0].Layers["mri"].SHA).NotTo(Equal(firstImage.Buildpacks[0].Layers["mri"].SHA))
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

According to https://www.ruby-lang.org/en/downloads/branches/, MRI 2.6.x went out of support on 2022-03-31.

This PR removes it from the dependencies set.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
