### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MRI Cloud Native Buildpack
+# Paketo Buildpack for MRI
 
 ## `gcr.io/paketo-buildpacks/mri`
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/mri"
   id = "paketo-buildpacks/mri"
   keywords = ["ruby", "mri"]
-  name = "Paketo MRI Buildpack"
+  name = "Paketo Buildpack for MRI"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo MRI Buildpack' to 'Paketo Buildpack for MRI'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
