### PR TITLE
compile against stack image

### DIFF
--- a/dependency/actions/compile/bionic.Dockerfile
+++ b/dependency/actions/compile/bionic.Dockerfile
@@ -1,9 +1,6 @@
-FROM ubuntu:bionic
+FROM paketobuildpacks/build-bionic-full
 
 ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get -y update && \
-  apt-get -y install openssl libffi-dev libssl-dev autoconf bison gperf ruby zlib1g-dev libyaml-dev curl build-essential
 
 
 COPY entrypoint /entrypoint

--- a/dependency/actions/compile/jammy.Dockerfile
+++ b/dependency/actions/compile/jammy.Dockerfile
@@ -1,9 +1,6 @@
-FROM ubuntu:jammy
+FROM paketobuildpacks/build-jammy-full
 
 ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get -y update && \
-  apt-get -y install openssl libffi-dev libssl-dev autoconf bison gperf ruby zlib1g-dev libyaml-dev curl build-essential
 
 COPY entrypoint /entrypoint
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

#452 

Does not test the dependency against the stack image, because we run into permissions issues untarring the dependency. I think the main goal of the test we have is to make sure that the dependency is structure correctly/can run, and less that it works on the stack specifically (we test this in the buildpack itself). We could get around issues by changing the user ID in the test Dockerfile but that does not seem worthwhile.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
