### PR TITLE
Adds a dependency-constraint to start pulling in MRI 3.2.* versions

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -137,6 +137,11 @@ api = "0.7"
     id = "ruby"
     patches = 2
 
+  [[metadata.dependency-constraints]]
+    constraint = "3.2.*"
+    id = "ruby"
+    patches = 2
+
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Ruby 3.2 [was released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) during the holiday break. This buildpack should start to support that version line.

This PR only adds the dependency constraint and will rely upon a subsequent PR (created by automation) to actually build and add the 3.2.* versions of Ruby.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This will allow users to target Ruby 3.2 for their applications.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
