### PR TITLE
Compile dependency as root

### DIFF
--- a/dependency/actions/compile/bionic.Dockerfile
+++ b/dependency/actions/compile/bionic.Dockerfile
@@ -2,6 +2,10 @@ FROM paketobuildpacks/build-bionic-full
 
 ENV DEBIAN_FRONTEND noninteractive
 
+ARG cnb_uid=0
+ARG cnb_gid=0
+
+USER ${cnb_uid}:${cnb_gid}
 
 COPY entrypoint /entrypoint
 

--- a/dependency/actions/compile/jammy.Dockerfile
+++ b/dependency/actions/compile/jammy.Dockerfile
@@ -2,6 +2,11 @@ FROM paketobuildpacks/build-jammy-full
 
 ENV DEBIAN_FRONTEND noninteractive
 
+ARG cnb_uid=0
+ARG cnb_gid=0
+
+USER ${cnb_uid}:${cnb_gid}
+
 COPY entrypoint /entrypoint
 
 ENTRYPOINT ["/entrypoint"]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves failures seen in #456 by setting the user as root for compilation.
Compilation of the Ruby dependency has been failing, not due to the new version, but with `permission denied` errors because we [recently switched to compiling against the stack image](https://github.com/paketo-buildpacks/mri/pull/453).

I have tested this change here: https://github.com/paketo-buildpacks/mri/actions/runs/4000408894/jobs/6865512717, which has resulted in successful compilation of ruby 3.2.0.

It's worth noting that I wasn't able to reproduce compilation failures locally (on my Mac), which explains why I didn't run into this issue when I originally switched compilation to run on the stack image.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
