### PR TITLE
Removes support for MRI 2.7.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ file that looks like the following:
   # is not specified, the buildpack will provide the default version, which can
   # be seen in the buildpack.toml file.
   # If you wish to request a specific version, the buildpack supports
-  # specifying a semver constraint in the form of "2.*", "2.7.*", or even
-  # "2.7.1".
-  version = "2.7.1"
+  # specifying a semver constraint in the form of "3.*", "3.2.*", or even
+  # "3.2.1".
+  version = "3.2.1"
   # The MRI buildpack supports some non-required metadata options.
   [requires.metadata]
     # Setting the build flag to true will ensure that the MRI
@@ -50,16 +50,16 @@ deprecated in MRI Buildpack v1.0.0.
 
 To migrate from using `buildpack.yml` please set the `$BP_MRI_VERSION`
 environment variable at build time either directly (ex. `pack build my-app
---env BP_MRI_VERSION=2.7.*`) or through a [`project.toml`
+--env BP_MRI_VERSION=3.2.*`) or through a [`project.toml`
 file](https://github.com/buildpacks/spec/blob/main/extensions/project-descriptor.md)
 
 ```shell
-$BP_MRI_VERSION="2.7.1"
+$BP_MRI_VERSION="3.2.1"
 ```
 This will replace the following structure in `buildpack.yml`:
 ```yaml
 mri:
-  version: 2.7.1
+  version: 3.2.1
 ```
 
 ## Logging Configurations

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,32 +19,6 @@ api = "0.7"
     ruby = "3.1.*"
 
   [[metadata.dependencies]]
-    checksum = "sha256:1e003b9b9753d81a076a8034bc70efbed6be6c2d25e5c62c9f50bacf5c166f25"
-    cpe = "cpe:2.3:a:ruby-lang:ruby:2.7.7:*:*:*:*:*:*:*"
-    id = "ruby"
-    licenses = ["BSD-2-Clause", "BSD-2-Clause-NetBSD", "BSD-3-Clause", "BSD-3-Clause-No-Nuclear-License-2014", "Bison-exception-2.2", "GPL-2.0-only", "GPL-2.0-or-later", "MIT", "MIT-0", "Ruby", "deprecated_GPL-2.0", "deprecated_GPL-2.0+"]
-    name = "Ruby"
-    purl = "pkg:generic/ruby@2.7.7?checksum=e10127db691d7ff36402cfe88f418c8d025a3f1eea92044b162dd72f0b8c7b90&download_url=https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.gz"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.gz"
-    source-checksum = "sha256:e10127db691d7ff36402cfe88f418c8d025a3f1eea92044b162dd72f0b8c7b90"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://artifacts.paketo.io/ruby/ruby_2.7.7_linux_x64_bionic_1e003b9b.tgz"
-    version = "2.7.7"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:f0757bb4651a1804328b267c26dbe1a2e8ffcf0e1f04e20f7219ea267634d858"
-    cpe = "cpe:2.3:a:ruby-lang:ruby:2.7.8:*:*:*:*:*:*:*"
-    id = "ruby"
-    licenses = ["BSD-2-Clause", "BSD-2-Clause-NetBSD", "BSD-3-Clause", "BSD-3-Clause-No-Nuclear-License-2014", "Bison-exception-2.2", "GPL-2.0-only", "GPL-2.0-or-later", "MIT", "MIT-0", "Ruby", "deprecated_GPL-2.0", "deprecated_GPL-2.0+"]
-    name = "Ruby"
-    purl = "pkg:generic/ruby@2.7.8?checksum=c2dab63cbc8f2a05526108ad419efa63a67ed4074dbbcf9fc2b1ca664cb45ba0&download_url=https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.8.tar.gz"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.8.tar.gz"
-    source-checksum = "sha256:c2dab63cbc8f2a05526108ad419efa63a67ed4074dbbcf9fc2b1ca664cb45ba0"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://artifacts.paketo.io/ruby/ruby_2.7.8_linux_x64_bionic_f0757bb4.tgz"
-    version = "2.7.8"
-
-  [[metadata.dependencies]]
     checksum = "sha256:0de6dcaca9e8dd1efdcf07e400eab8a7a8f19b5b5bdf206cd8da16b59f93752c"
     cpe = "cpe:2.3:a:ruby-lang:ruby:3.0.5:*:*:*:*:*:*:*"
     id = "ruby"
@@ -173,11 +147,6 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.bionic"]
     uri = "https://artifacts.paketo.io/ruby/ruby_3.2.2_linux_x64_bionic_135d83aa.tgz"
     version = "3.2.2"
-
-  [[metadata.dependency-constraints]]
-    constraint = "2.7.*"
-    id = "ruby"
-    patches = 2
 
   [[metadata.dependency-constraints]]
     constraint = "3.0.*"

--- a/dependency/retrieval/components/releases_test.go
+++ b/dependency/retrieval/components/releases_test.go
@@ -160,14 +160,14 @@ func testReleaseFetcher(t *testing.T, context spec.G, it spec.S) {
 					releases, err := releaseFetcher.GetUpstreamReleases()
 					Expect(err).To(Not(HaveOccurred()))
 					Expect(releases).To(Not(BeEmpty()))
-					Expect(releases["2.7.3"]).To(Equal(
+					Expect(releases["3.2.1"]).To(Equal(
 						components.RubyRelease{
-							Version: "2.7.3",
+							Version: "3.2.1",
 							URL: components.URL{
-								Gz: "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.gz",
+								Gz: "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz",
 							},
 							SHA256: components.SHA256{
-								Gz: "8925a95e31d8f2c81749025a52a544ea1d05dad18794e6828709268b92e55338",
+								Gz: "13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd",
 							},
 						}))
 				})

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -93,7 +93,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 							settings.Buildpacks.BuildPlan.Online,
 						).
 						WithEnv(map[string]string{
-							"BP_MRI_VERSION": "2.7.*",
+							"BP_MRI_VERSION": "3.0.*",
 							"BP_LOG_LEVEL":   "DEBUG",
 						}).
 						Execute(name, source)
@@ -108,7 +108,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 					Expect(err).NotTo(HaveOccurred())
 
 					Eventually(container).Should(BeAvailable(), logs.String())
-					Eventually(container).Should(Serve(MatchRegexp(`Hello from Ruby 2\.7\.\d+`)).OnPort(8080))
+					Eventually(container).Should(Serve(MatchRegexp(`Hello from Ruby 3\.0\.\d+`)).OnPort(8080))
 				})
 			})
 		}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Per https://www.ruby-lang.org/en/downloads/branches/, Ruby 2.7 EOL date was 2023-03-31, with normal maintenance until 2022-04-01.

As a result, we should now remove Ruby 2.7 from the buildpack

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
