### PR TITLE
Use default instead of override for Gem path env var.

### DIFF
--- a/build.go
+++ b/build.go
@@ -186,7 +186,7 @@ func Build(
 			return packit.BuildResult{}, err
 		}
 
-		mriLayer.SharedEnv.Override("GEM_PATH", strings.TrimSpace(buffer.String()))
+		mriLayer.SharedEnv.Default("GEM_PATH", strings.TrimSpace(buffer.String()))
 		mriLayer.SharedEnv.Default("MALLOC_ARENA_MAX", "2")
 
 		logger.EnvironmentVariables(mriLayer)

--- a/build_test.go
+++ b/build_test.go
@@ -144,7 +144,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(layer.SharedEnv).To(Equal(packit.Environment{
 			"MALLOC_ARENA_MAX.default": "2",
-			"GEM_PATH.override":        "/some/mri/gems/path",
+			"GEM_PATH.default":        "/some/mri/gems/path",
 		}))
 		Expect(layer.BuildEnv).To(BeEmpty())
 		Expect(layer.LaunchEnv).To(BeEmpty())


### PR DESCRIPTION
## Summary / Use Cases

This PR sets the `GEM_PATH` environment variable to `default` instead of `override` so that users can override it if necessary. See https://github.com/paketo-buildpacks/rfcs/issues/64

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
