### PR TITLE
Compile Ruby >= 3.2 with YJIT support

### DIFF
--- a/dependency/actions/compile/entrypoint
+++ b/dependency/actions/compile/entrypoint
@@ -7,12 +7,13 @@ shopt -s inherit_errexit
 DEST_DIR=$(mktemp -d)
 
 function main() {
-  local version output_dir target upstream_tarball working_dir
+  local version output_dir target upstream_tarball working_dir configure_opts
   version=""
   output_dir=""
   target=""
   upstream_tarball=""
   working_dir=$(mktemp -d)
+  configure_opts=()
 
   while [ "${#}" != 0 ]; do
     case "${1}" in
@@ -64,6 +65,10 @@ function main() {
     exit 1
   fi
 
+  if [[ "${major}" -ge 3 ]] && [[ "${minor}" -ge 2 ]]; then
+    configure_opts+=("--enable-yjit")
+  fi
+
   echo "version=${version}"
   echo "output_dir=${output_dir}"
   echo "target=${target}"
@@ -87,7 +92,8 @@ function main() {
       ./configure \
       --enable-load-relative \
       --disable-install-doc \
-      --prefix="${DEST_DIR}"
+      --prefix="${DEST_DIR}" \
+      "${configure_opts[@]}"
 
       echo "Running make install"
       make install

--- a/dependency/actions/compile/jammy.Dockerfile
+++ b/dependency/actions/compile/jammy.Dockerfile
@@ -7,6 +7,11 @@ ARG cnb_gid=0
 
 USER ${cnb_uid}:${cnb_gid}
 
+RUN apt-get -y update && \
+  apt-get -y upgrade && \
+  apt-get -y install rustc && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /etc/apt/preferences
+
 COPY entrypoint /entrypoint
 
 ENTRYPOINT ["/entrypoint"]


### PR DESCRIPTION
## Summary

Ruby >= 3.2 supports YJIT, which is a small just-in-time compiler that runs inside CRuby, and brings improved performance and, in certain cases, improved memory utilization.

The official documentation for YJIT exists inside the Ruby repository [here](https://github.com/ruby/ruby/blob/master/doc/yjit/yjit.md).

This PR makes two small changes:
  * Add `rustc` to the compilation image. Rust is only needed during Ruby compilation and is not necessary during runtime.
  * Compiles Ruby >= 2.3 with `--enable-yjit`

The above compiles Ruby with YJIT support, but does not automatically enable the use of YJIT for Ruby applications. In order to use YJIT, applications must either:
  * Pass `--yjit` to `ruby`.
  * Set the `RUBY_YJIT_ENABLE` environment variable.

For example:

```sh
$ ruby --version
ruby 3.2.3 (2024-01-18 revision 52bb2ac0a6) [x86_64-linux]
$ ruby --yjit --version
ruby 3.2.3 (2024-01-18 revision 52bb2ac0a6) +YJIT [x86_64-linux]
$ env RUBY_YJIT_ENABLE=1 ruby --version
ruby 3.2.3 (2024-01-18 revision 52bb2ac0a6) +YJIT [x86_64-linux]
```

Closes https://github.com/paketo-buildpacks/mri/issues/636

## Use Cases

Long running processes such as Rails web applications will likely benefit a lot from this setting, and it's likely to become enabled by default in the future.

https://shopify.engineering/ruby-yjit-is-production-ready
https://speed.yjit.org/benchmarks/bench-2021-10-13-070947
https://railsatscale.com/2023-12-04-ruby-3-3-s-yjit-faster-while-using-less-memory/
https://geeks.wego.com/ruby-is-dead-long-live-ruby-with-yjit/
https://dev.37signals.com/yjit-is-fast/

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
